### PR TITLE
add text form to input published message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # ZenohexPhoenixDemo
 
+Note: we only confirmed the operation of this repository on the cloud VM in `MIX_ENV=prod`
+
 To start your Phoenix server:
 
-  * Run `mix setup` to install and setup dependencies
-  * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+  * Adjust [config/config.exs#L15](https://github.com/b5g-ex/zenohex_phoenix_demo/blob/main/config/config.exs#L15) and [config/runtime.exs#L36](https://github.com/b5g-ex/zenohex_phoenix_demo/blob/main/config/runtime.exs#L36) to your server's URL
+  * Run `mix deps.get --only prod` to install and setup dependencies
+  * Run `MIX_ENV=prod mix compile` to compile project
+  * Run `MIX_ENV=prod mix assets.deploy` to assets
+  * Run `MIX_ENV=prod mix phx.gen.secret`, and set the result to `$SECRET_KEY_BASE`
+  * Then, start Phoenix endpoint with `MIX_ENV=prod mix phx.server` or inside IEx with `MIX_ENV=prod iex -S mix phx.server`
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+Now you can visit `<your_vm_url>:4000` from your browser.
 
 ## Learn more
 

--- a/lib/zenohex_phoenix_demo/zenohex_manager.ex
+++ b/lib/zenohex_phoenix_demo/zenohex_manager.ex
@@ -8,8 +8,8 @@ defmodule ZenohexPhoenixDemo.ZenohexManager do
   def init(args) do
     session = Map.fetch!(args, :session)
     key_expr = Map.fetch!(args, :key_expr)
-    {:ok, subscriber} = Zenohex.Session.declare_subscriber(session, "demo/example/zenohex-elixir-put")
-    {:ok, publisher} = Zenohex.Session.declare_publisher(session, "demo/example/zenohex-phoenix-put")
+    {:ok, subscriber} = Zenohex.Session.declare_subscriber(session, "key/expression")
+    {:ok, publisher} = Zenohex.Session.declare_publisher(session, "key/expression")
 
     state = %{subscriber: subscriber, publisher: publisher, callback: &callback/1, msgs: []}
 

--- a/lib/zenohex_phoenix_demo_web/live/zenohex_live.ex
+++ b/lib/zenohex_phoenix_demo_web/live/zenohex_live.ex
@@ -12,7 +12,10 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
   def render(assigns) do
     ~L"""
     <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl">Zenohex demo</h1>
-    <button phx-click="pub" class="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900"> Pubish Message</button>
+    <form phx-submit="pub">
+    <label>Message: <input id="msg" type="text" name="input_value" /></label>
+    <button class="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900"> Pubish </button>
+    </form>
     <div>
       <label>subscribe</label>
       <textarea rows=20 class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"><%= @msgs %></textarea>
@@ -21,8 +24,8 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
     """
   end
 
-  def handle_event("pub", _value, socket) do
-    GenServer.call(ZenohexPhoenixDemo.ZenohexManager, {:put, "Pub from Elixir/Phoenix!"})
+  def handle_event("pub", %{"input_value" => msg}, socket) do
+    GenServer.call(ZenohexPhoenixDemo.ZenohexManager, {:put, msg})
     {:noreply, socket}
   end
 
@@ -41,5 +44,9 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
     msgs = GenServer.call(ZenohexPhoenixDemo.ZenohexManager, :get_msgs)
     |> Enum.join("\n")
     {:noreply, assign(socket, :msgs, msgs)}
+  end
+
+  def handle_event("send-msg", %{"input_value" => msg}, socket) do
+    {:noreply, assign(socket, :text_value, msg)}
   end
 end


### PR DESCRIPTION
テキストフォームを設けて出版したい文字列を入力できるようにした．
デモ・チュートリアル用にtopic名を `key/expression` に変更しているのと #1 も含めていることにご注意ください．

![image](https://github.com/b5g-ex/zenohex_phoenix_demo/assets/23649012/101e92f4-4ebf-4605-9bd7-e0e0e4743891)
