### PR TITLE
Refactoring for SWEST26 handson

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 26.2.5
+elixir 1.16.3-otp-26

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # ZenohexPhoenixDemo
 
+## Deploy locally
+
+This operation can be confirmed in `MIX_ENV=dev` or default setting.
+
+  * Run `mix setup` to install and setup dependencies
+  * Run `mix compile` to compile project
+  * Then, start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+
+Now you can visit `http://localhost:4000` from your browser.
+
+## Deploy on the cloud (or servers)
+
 Note: we only confirmed the operation of this repository on the cloud VM in `MIX_ENV=prod`
 
 To start your Phoenix server:
@@ -11,7 +23,7 @@ To start your Phoenix server:
   * Run `MIX_ENV=prod mix phx.gen.secret`, and set the result to `$SECRET_KEY_BASE`
   * Then, start Phoenix endpoint with `MIX_ENV=prod mix phx.server` or inside IEx with `MIX_ENV=prod iex -S mix phx.server`
 
-Now you can visit `<your_vm_url>:4000` from your browser.
+Now you can visit `http://<your_vm_url>:4000` from your browser.
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # ZenohexPhoenixDemo
 
+Note: we only confirmed the operation of this repository on the cloud VM in `MIX_ENV=prod`
+
 To start your Phoenix server:
 
-  * Run `mix setup` to install and setup dependencies
-  * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+  * Adjust [config/config.exs#L15](https://github.com/b5g-ex/zenohex_phoenix_demo/blob/main/config/config.exs#L15) and [config/runtime.exs#L36](https://github.com/b5g-ex/zenohex_phoenix_demo/blob/main/config/runtime.exs#L36) to your server's URL
+  * Run `mix deps.get --only prod` to install and setup dependencies
+  * Run `MIX_ENV=prod mix compile` to compile project
+  * Run `MIX_ENV=prod mix assets.deploy` to assets
+  * Run `MIX_ENV=prod mix phx.gen.secret`, and set the result to `$SECRET_KEY_BASE`
+  * Then, start Phoenix endpoint with `MIX_ENV=prod mix phx.server` or inside IEx with `MIX_ENV=prod iex -S mix phx.server`
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+Now you can visit `<your_vm_url>:4000` from your browser.
 
 ## Learn more
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,7 +9,7 @@ import Config
 config :zenohex_phoenix_demo, ZenohexPhoenixDemoWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/lib/zenohex_phoenix_demo/zenohex_manager.ex
+++ b/lib/zenohex_phoenix_demo/zenohex_manager.ex
@@ -1,5 +1,6 @@
 defmodule ZenohexPhoenixDemo.ZenohexManager do
   use GenServer
+  require Logger
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -7,7 +8,7 @@ defmodule ZenohexPhoenixDemo.ZenohexManager do
 
   def init(args) do
     session = Map.fetch!(args, :session)
-    key_expr = Map.fetch!(args, :key_expr)
+    # key_expr = Map.fetch!(args, :key_expr)
     {:ok, subscriber} = Zenohex.Session.declare_subscriber(session, "key/expression")
     {:ok, publisher} = Zenohex.Session.declare_publisher(session, "key/expression")
 

--- a/lib/zenohex_phoenix_demo/zenohex_manager.ex
+++ b/lib/zenohex_phoenix_demo/zenohex_manager.ex
@@ -8,8 +8,8 @@ defmodule ZenohexPhoenixDemo.ZenohexManager do
   def init(args) do
     session = Map.fetch!(args, :session)
     key_expr = Map.fetch!(args, :key_expr)
-    {:ok, subscriber} = Zenohex.Session.declare_subscriber(session, "demo/example/zenohex-elixir-put")
-    {:ok, publisher} = Zenohex.Session.declare_publisher(session, "demo/example/zenohex-phoenix-put")
+    {:ok, subscriber} = Zenohex.Session.declare_subscriber(session, "key/expression")
+    {:ok, publisher} = Zenohex.Session.declare_publisher(session, "key/expression")
 
     state = %{subscriber: subscriber, publisher: publisher, callback: &callback/1, msgs: []}
 

--- a/lib/zenohex_phoenix_demo_web/live/zenohex_live.ex
+++ b/lib/zenohex_phoenix_demo_web/live/zenohex_live.ex
@@ -12,7 +12,10 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
   def render(assigns) do
     ~L"""
     <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl">Zenohex demo</h1>
-    <button phx-click="pub" class="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900"> Pubish Message</button>
+    <form phx-submit="pub">
+    <label>Message: <input id="msg" type="text" name="input_value" /></label>
+    <button class="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900"> Pubish </button>
+    </form>
     <div>
       <label>subscribe</label>
       <textarea rows=20 class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"><%= @msgs %></textarea>
@@ -21,8 +24,8 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
     """
   end
 
-  def handle_event("pub", _value, socket) do
-    GenServer.call(ZenohexPhoenixDemo.ZenohexManager, {:put, "Pub from Elixir/Phoenix!"})
+  def handle_event("pub", %{"input_value" => msg}, socket) do
+    GenServer.call(ZenohexPhoenixDemo.ZenohexManager, {:put, msg})
     {:noreply, socket}
   end
 
@@ -41,5 +44,9 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
     msgs = GenServer.call(ZenohexPhoenixDemo.ZenohexManager, :get_msgs)
     |> Enum.join("\n")
     {:noreply, assign(socket, :msgs, msgs)}
+  end
+
+  def handle_event("send-msg", %{"input_value" => msg}, socket) do
+    {:noreply, assign(socket, :text_value, msg)}
   end
 end

--- a/lib/zenohex_phoenix_demo_web/live/zenohex_live.ex
+++ b/lib/zenohex_phoenix_demo_web/live/zenohex_live.ex
@@ -1,6 +1,5 @@
 defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
   use ZenohexPhoenixDemoWeb, :live_view
-  alias Zenohex.Examples.Subscriber
   def mount(_param, _session, socket) do
     if connected?(socket), do: Process.send_after(self(), :update, 500)
 
@@ -10,7 +9,7 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
   end
 
   def render(assigns) do
-    ~L"""
+    ~H"""
     <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl">Zenohex demo</h1>
     <form phx-submit="pub">
     <label>Message: <input id="msg" type="text" name="input_value" /></label>
@@ -18,7 +17,7 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
     </form>
     <div>
       <label>subscribe</label>
-      <textarea rows=20 class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"><%= @msgs %></textarea>
+      <textarea rows="20" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"><%= @msgs %></textarea>
     </div>
     <button phx-click="clear" class="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900"> Clear</button>
     """
@@ -27,6 +26,10 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
   def handle_event("pub", %{"input_value" => msg}, socket) do
     GenServer.call(ZenohexPhoenixDemo.ZenohexManager, {:put, msg})
     {:noreply, socket}
+  end
+
+  def handle_event("send-msg", %{"input_value" => msg}, socket) do
+    {:noreply, assign(socket, :text_value, msg)}
   end
 
   def handle_event("clear", _value, socket) do
@@ -44,9 +47,5 @@ defmodule ZenohexPhoenixDemoWeb.ZenohexLive do
     msgs = GenServer.call(ZenohexPhoenixDemo.ZenohexManager, :get_msgs)
     |> Enum.join("\n")
     {:noreply, assign(socket, :msgs, msgs)}
-  end
-
-  def handle_event("send-msg", %{"input_value" => msg}, socket) do
-    {:noreply, assign(socket, :text_value, msg)}
   end
 end

--- a/lib/zenohex_phoenix_demo_web/router.ex
+++ b/lib/zenohex_phoenix_demo_web/router.ex
@@ -18,7 +18,7 @@ defmodule ZenohexPhoenixDemoWeb.Router do
     pipe_through :browser
     live "/", ZenohexLive
 
-    get "/", PageController, :home
+    # get "/", PageController, :home
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
SWEST26でのハンズオンでの利用を想定してリファクタリングしています．
#1 と #2 の変更も含まれています．

- `.tool-version` を整備（ハンズオンには不要だが念のため）
- Warningをなるべく抑止
- Endpoint IPを `0.0.0.0` に変更してDocker内部で立ち上げてもアクセスできるようにした
- `http://localhost:4000` なら `MIX_ENV=dev` でも実行できるのでその手順を記載
